### PR TITLE
fix: utiliser une confirmation stable pour supprimer une table

### DIFF
--- a/components/admin/delete-table-danger-zone.test.tsx
+++ b/components/admin/delete-table-danger-zone.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteTableDangerZone } from "./delete-table-danger-zone";
+import { useTableStore } from "@/store/table-store";
+
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push, refresh }),
+}));
+
+vi.mock("@/store/table-store");
+
+describe("DeleteTableDangerZone", () => {
+    const deleteTable = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        deleteTable.mockResolvedValue({ success: true });
+        vi.mocked(useTableStore).mockReturnValue({
+            deleteTable,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useTableStore>);
+    });
+
+    it("uses a stable confirmation word instead of the table name", async () => {
+        render(
+            <DeleteTableDangerZone
+                tableId="table-123"
+                tableName={'La table des héros / été 2026 !'}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Supprimer la table" }));
+
+        const confirmationInput = screen.getByPlaceholderText("SUPPRIMER");
+        const deleteButton = screen.getByRole("button", { name: "Supprimer définitivement" });
+
+        expect(deleteButton).toBeDisabled();
+
+        fireEvent.change(confirmationInput, {
+            target: { value: "La table des héros / été 2026 !" },
+        });
+        expect(deleteButton).toBeDisabled();
+
+        fireEvent.change(confirmationInput, { target: { value: "SUPPRIMER" } });
+        expect(deleteButton).toBeEnabled();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => {
+            expect(deleteTable).toHaveBeenCalledWith("table-123");
+            expect(push).toHaveBeenCalledWith("/tables");
+            expect(refresh).toHaveBeenCalled();
+        });
+    });
+});

--- a/components/admin/delete-table-danger-zone.tsx
+++ b/components/admin/delete-table-danger-zone.tsx
@@ -16,6 +16,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { useTableStore } from "@/store/table-store";
 
+const DELETE_CONFIRMATION = "SUPPRIMER";
+
 type DeleteTableDangerZoneProps = Readonly<{
     tableId: string;
     tableName: string;
@@ -28,7 +30,7 @@ export function DeleteTableDangerZone({ tableId, tableName }: DeleteTableDangerZ
     const [confirmation, setConfirmation] = useState("");
     const [error, setError] = useState<string | null>(null);
 
-    const canDelete = confirmation === tableName;
+    const canDelete = confirmation === DELETE_CONFIRMATION;
 
     const handleOpenChange = (open: boolean) => {
         if (open) {
@@ -80,16 +82,16 @@ export function DeleteTableDangerZone({ tableId, tableName }: DeleteTableDangerZ
                         <DialogHeader>
                             <DialogTitle>Supprimer la table</DialogTitle>
                             <DialogDescription>
-                                Cette action supprimera la table, ses sessions, invitations,
-                                messages, notes et journaux liés. Une session live doit être
-                                clôturée ou annulée avant suppression.
+                                Cette action supprimera la table « {tableName} », ses sessions,
+                                invitations, messages, notes et journaux liés. Une session live doit
+                                être clôturée ou annulée avant suppression.
                             </DialogDescription>
                         </DialogHeader>
 
                         <div className="space-y-3">
                             <div className="bg-destructive/10 text-destructive border-destructive/20 rounded-lg border p-3 text-sm font-medium">
                                 Pour confirmer, saisissez exactement :{" "}
-                                <span className="font-bold">{tableName}</span>
+                                <span className="font-bold">{DELETE_CONFIRMATION}</span>
                             </div>
                             <Input
                                 value={confirmation}
@@ -97,7 +99,7 @@ export function DeleteTableDangerZone({ tableId, tableName }: DeleteTableDangerZ
                                     setConfirmation(event.target.value);
                                     setError(null);
                                 }}
-                                placeholder={tableName}
+                                placeholder={DELETE_CONFIRMATION}
                                 autoComplete="off"
                             />
                             {error && (


### PR DESCRIPTION
## Ce qui change

- remplace la confirmation basée sur le nom de la table par le mot fixe `SUPPRIMER` ;
- conserve le nom de la table dans le texte descriptif pour rappeler la cible de l’action ;
- ajoute un test de composant couvrant un nom avec espaces et caractères spéciaux.

## Pourquoi

La comparaison stricte avec le nom de la table rendait la suppression fragile pour les noms contenant des espaces ou des caractères spéciaux. Une confirmation fixe évite également que le comportement dépende de valeurs utilisateur arbitraires.

## Validation

- test de composant ajouté pour vérifier que le nom de la table ne valide plus la suppression ;
- vérification que `SUPPRIMER` active l’action et appelle bien la suppression puis la redirection.

Closes #108