### PR TITLE
perf: optimiser le chargement de la page tables

### DIFF
--- a/docs/devlog/2026-07.md
+++ b/docs/devlog/2026-07.md
@@ -1,0 +1,23 @@
+# Devlog - Juillet 2026
+
+## 2026-07-21 15:00
+
+### Sujet
+
+Optimisation du chargement de la page `/tables`.
+
+### Changements
+
+- Remplacement du listing pagine et de son `count` inutilise par une requete compacte dediee a la page.
+- Recuperation du role utilisateur dans la meme requete que les tables.
+- Chargement groupe des sessions `scheduled` et `active` pour toutes les tables.
+- Reconstruction des resumes de table cote service sans requete par table.
+- Ajout de tests couvrant l'absence de table, plusieurs roles, la prochaine session et la session active.
+
+### Impact
+
+Le nombre de requetes Supabase de `TableService.listUserTables()` devient constant, independamment du nombre de tables de l'utilisateur. Le contrat de rendu et les permissions restent inchanges.
+
+### Vigilance
+
+Cette passe ne traite pas encore le double chargement d'authentification entre le proxy, le Server Component et l'hydratation client de `AuthProvider`.

--- a/lib/repositories/session-repository.ts
+++ b/lib/repositories/session-repository.ts
@@ -81,6 +81,26 @@ export const SessionRepository = {
         };
     },
 
+    /**
+     * Load all scheduled and active sessions used by the /tables summaries.
+     * The caller groups the rows by table, keeping the query count constant.
+     */
+    async listSummarySessionsByTableIds(tableIds: string[]): Promise<Session[]> {
+        if (tableIds.length === 0) {
+            return [];
+        }
+
+        const supabase = await getServerClient();
+        const { data, error } = await supabase
+            .from("sessions")
+            .select("*")
+            .in("table_id", tableIds)
+            .in("status", ["scheduled", "active"]);
+
+        handleDbError(error, "SessionRepository.listSummarySessionsByTableIds");
+        return data || [];
+    },
+
     async getNextSession(tableId: string): Promise<Session | null> {
         const supabase = await getServerClient();
 

--- a/lib/repositories/table-repository.ts
+++ b/lib/repositories/table-repository.ts
@@ -4,6 +4,19 @@ import { NotFoundError } from "@/lib/errors";
 import { Table, TableRole } from "@/types/table";
 import { CreateTableInput, UpdateTableInput } from "@/lib/validators/table";
 
+export interface UserTableSummaryRow {
+    id: string;
+    name: string;
+    description: string | null;
+    myRole: TableRole;
+}
+
+type TableWithMembershipRole = Pick<Table, "id" | "name" | "description"> & {
+    table_memberships: Array<{
+        role: TableRole;
+    }>;
+};
+
 export const TableRepository = {
     async create(input: CreateTableInput, ownerId: string): Promise<Table> {
         const supabase = await getServerClient();
@@ -58,6 +71,28 @@ export const TableRepository = {
         const { error } = await supabase.from("tables").delete().eq("id", id);
 
         handleDbError(error, "TableRepository.delete");
+    },
+
+    /**
+     * List the compact table data required by /tables without an unused count query.
+     * The authenticated user's role is embedded in the same database request.
+     */
+    async listSummariesByUserId(userId: string): Promise<UserTableSummaryRow[]> {
+        const supabase = await getServerClient();
+        const { data, error } = await supabase
+            .from("tables")
+            .select("id, name, description, table_memberships!inner(role)")
+            .eq("table_memberships.user_id", userId);
+
+        handleDbError(error, "TableRepository.listSummariesByUserId");
+
+        const rows = (data || []) as unknown as TableWithMembershipRole[];
+        return rows.map((row) => ({
+            id: row.id,
+            name: row.name,
+            description: row.description,
+            myRole: row.table_memberships[0]?.role || "player",
+        }));
     },
 
     async listByUserId(

--- a/lib/services/tables/table-service.test.ts
+++ b/lib/services/tables/table-service.test.ts
@@ -14,11 +14,116 @@ describe("TableService", () => {
     const tableId = "table-123";
 
     type TableById = Awaited<ReturnType<typeof TableRepository.getById>>;
+    type SummaryTable = Awaited<ReturnType<typeof TableRepository.listSummariesByUserId>>[number];
     type Membership = Awaited<ReturnType<typeof MembershipService.requireMembership>>;
     type ActiveSession = Awaited<ReturnType<typeof SessionRepository.getActiveSessionByTable>>;
+    type SummarySession = Awaited<
+        ReturnType<typeof SessionRepository.listSummarySessionsByTableIds>
+    >[number];
 
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe("listUserTables", () => {
+        it("returns immediately without loading sessions when the user has no table", async () => {
+            vi.mocked(TableRepository.listSummariesByUserId).mockResolvedValue([]);
+
+            await expect(TableService.listUserTables(userId)).resolves.toEqual([]);
+
+            expect(TableRepository.listSummariesByUserId).toHaveBeenCalledOnce();
+            expect(TableRepository.listSummariesByUserId).toHaveBeenCalledWith(userId);
+            expect(SessionRepository.listSummarySessionsByTableIds).not.toHaveBeenCalled();
+            expect(MembershipService.getMembership).not.toHaveBeenCalled();
+        });
+
+        it("builds all table summaries with one table query and one grouped session query", async () => {
+            const tables = [
+                {
+                    id: "table-1",
+                    name: "Table principale",
+                    description: "Campagne principale",
+                    myRole: "gm",
+                },
+                {
+                    id: "table-2",
+                    name: "Table observée",
+                    description: null,
+                    myRole: "observer",
+                },
+                {
+                    id: "table-3",
+                    name: "Table sans session",
+                    description: null,
+                    myRole: "player",
+                },
+            ] as SummaryTable[];
+
+            const laterSession = {
+                id: "scheduled-later",
+                table_id: "table-1",
+                title: "Session de septembre",
+                status: "scheduled",
+                scheduled_at: "2026-09-10T18:00:00.000Z",
+            } as SummarySession;
+            const activeSession = {
+                id: "active-1",
+                table_id: "table-1",
+                title: "Session en cours",
+                status: "active",
+                scheduled_at: "2026-08-01T18:00:00.000Z",
+            } as SummarySession;
+            const earlierSession = {
+                id: "scheduled-earlier",
+                table_id: "table-1",
+                title: "Session d'août",
+                status: "scheduled",
+                scheduled_at: "2026-08-20T18:00:00.000Z",
+            } as SummarySession;
+            const undatedSession = {
+                id: "scheduled-undated",
+                table_id: "table-2",
+                title: "Session à planifier",
+                status: "scheduled",
+                scheduled_at: null,
+            } as SummarySession;
+
+            vi.mocked(TableRepository.listSummariesByUserId).mockResolvedValue(tables);
+            vi.mocked(SessionRepository.listSummarySessionsByTableIds).mockResolvedValue([
+                laterSession,
+                activeSession,
+                earlierSession,
+                undatedSession,
+            ]);
+
+            const result = await TableService.listUserTables(userId);
+
+            expect(TableRepository.listSummariesByUserId).toHaveBeenCalledTimes(1);
+            expect(SessionRepository.listSummarySessionsByTableIds).toHaveBeenCalledTimes(1);
+            expect(SessionRepository.listSummarySessionsByTableIds).toHaveBeenCalledWith([
+                "table-1",
+                "table-2",
+                "table-3",
+            ]);
+            expect(MembershipService.getMembership).not.toHaveBeenCalled();
+            expect(result).toEqual([
+                {
+                    ...tables[0],
+                    nextSession: earlierSession,
+                    activeSession,
+                },
+                {
+                    ...tables[1],
+                    nextSession: undatedSession,
+                    activeSession: null,
+                },
+                {
+                    ...tables[2],
+                    nextSession: null,
+                    activeSession: null,
+                },
+            ]);
+        });
     });
 
     it("deletes a table for its owner", async () => {

--- a/lib/services/tables/table-service.ts
+++ b/lib/services/tables/table-service.ts
@@ -22,31 +22,82 @@ export interface TableDetailsDTO {
     activeSession: Session | null;
 }
 
+interface TableSessionSummary {
+    nextSession: Session | null;
+    activeSession: Session | null;
+}
+
+function shouldUseAsNextSession(candidate: Session, current: Session | null): boolean {
+    if (!current) {
+        return true;
+    }
+
+    if (!candidate.scheduled_at) {
+        return false;
+    }
+
+    if (!current.scheduled_at) {
+        return true;
+    }
+
+    return candidate.scheduled_at < current.scheduled_at;
+}
+
+function groupSummarySessions(sessions: Session[]): Map<string, TableSessionSummary> {
+    const summaries = new Map<string, TableSessionSummary>();
+
+    for (const session of sessions) {
+        const summary = summaries.get(session.table_id) || {
+            nextSession: null,
+            activeSession: null,
+        };
+
+        if (session.status === "active" && !summary.activeSession) {
+            summary.activeSession = session;
+        }
+
+        if (
+            session.status === "scheduled" &&
+            shouldUseAsNextSession(session, summary.nextSession)
+        ) {
+            summary.nextSession = session;
+        }
+
+        summaries.set(session.table_id, summary);
+    }
+
+    return summaries;
+}
+
 export const TableService = {
     /**
      * List all tables for a user with role and next session summary.
+     * Uses one table query and one grouped session query, regardless of table count.
      */
     async listUserTables(userId: string): Promise<TableSummaryDTO[]> {
-        const paginatedTables = await TableRepository.listByUserId(userId);
+        const tables = await TableRepository.listSummariesByUserId(userId);
 
-        const summaries = await Promise.all(
-            paginatedTables.data.map(async (table) => {
-                const membership = await MembershipService.getMembership(userId, table.id);
-                const nextSession = await SessionRepository.getNextSession(table.id);
-                const activeSession = await SessionRepository.getActiveSessionByTable(table.id);
+        if (tables.length === 0) {
+            return [];
+        }
 
-                return {
-                    id: table.id,
-                    name: table.name,
-                    description: table.description,
-                    myRole: membership?.role || "player", // Fallback, though user should be member
-                    nextSession,
-                    activeSession,
-                };
-            }),
+        const sessions = await SessionRepository.listSummarySessionsByTableIds(
+            tables.map((table) => table.id),
         );
+        const sessionsByTable = groupSummarySessions(sessions);
 
-        return summaries;
+        return tables.map((table) => {
+            const summary = sessionsByTable.get(table.id);
+
+            return {
+                id: table.id,
+                name: table.name,
+                description: table.description,
+                myRole: table.myRole,
+                nextSession: summary?.nextSession || null,
+                activeSession: summary?.activeSession || null,
+            };
+        });
     },
 
     /**


### PR DESCRIPTION
## Résumé

- remplace le listing paginé et son `count` inutilisé par une requête compacte dédiée à `/tables` ;
- récupère le rôle du membre dans la même requête que les tables ;
- charge toutes les sessions `scheduled` et `active` dans une seule requête groupée ;
- reconstruit les résumés côté service, sans N+1 ;
- ajoute des tests pour utilisateur sans table, rôles multiples, prochaine session, session active et nombre constant d’appels ;
- ajoute l’entrée devlog de juillet.

## Impact attendu

`TableService.listUserTables()` passe d’un nombre de requêtes proportionnel au nombre de tables à :

- 1 requête pour les tables + rôle ;
- 1 requête pour les sessions de résumé ;
- 0 requête session lorsque l’utilisateur n’a aucune table.

Le contrat `TableSummaryDTO`, l’UI et les permissions RLS restent inchangés.

## Vérifications manuelles recommandées

- compte sans table ;
- compte joueur, observateur et MJ ;
- table sans session ;
- table avec prochaine session ;
- table avec session live ;
- comparer le temps de chargement `/tables` avant/après dans Vercel Speed Insights.

Closes #128